### PR TITLE
fixes from levels 4, 5 and 6

### DIFF
--- a/VidaDeInseto/VidaDeInseto/LevelFiveView.swift
+++ b/VidaDeInseto/VidaDeInseto/LevelFiveView.swift
@@ -63,13 +63,18 @@ struct LevelFiveView: View {
             .onChange(of: volObserver.volume) { _ in
                 if volObserver.volume == 1.0 {
                     print("volume máximo")
-                } else if volObserver.volume == 0.0 {
-                    print("volume mínimo")
                     levelCompleted = true
                     DispatchQueue.main.asyncAfter(deadline: .now() + 3.5){
                        nextLevel += 1
                        forestPlayer?.stop()
                     }
+                } else if volObserver.volume == 0.0 {
+                    print("volume mínimo")
+//                    levelCompleted = true
+//                    DispatchQueue.main.asyncAfter(deadline: .now() + 3.5){
+//                       nextLevel += 1
+//                       forestPlayer?.stop()
+//                    }
                 } else {
                     print("faz alguma coisa")
                 }

--- a/VidaDeInseto/VidaDeInseto/LevelFourView.swift
+++ b/VidaDeInseto/VidaDeInseto/LevelFourView.swift
@@ -37,7 +37,7 @@ struct LevelFourView: View {
                 .offset(x:20)
         
         VStack{
-            Text(text)
+//            Text(text)
             Button(action: {
                 self.alertIsPresented = true
             }, label: {
@@ -48,7 +48,7 @@ struct LevelFourView: View {
             .foregroundColor(.clear)
             .offset(x: 80, y: -20)
             .alert(isPresented: $alertIsPresented, content: {
-                Alert(title: Text("Um tempo para si é importante"), message: Text("Você e o Txai estão juntos há um tempo, que tal curtir sua própria companhia um pouco?"), dismissButton: .default(Text("Vamos lá!")))
+                Alert(title: Text("Um tempo para si é importante"), message: Text("Que tal curtir sua própria companhia um pouco? O Txai tem uma mensagem para você: \(text)"), dismissButton: .default(Text("Vamos lá!")))
             })
             Image(levelCompleted ? "happy-mushroom" : "angry-mushroom")
         }

--- a/VidaDeInseto/VidaDeInseto/LevelSixView.swift
+++ b/VidaDeInseto/VidaDeInseto/LevelSixView.swift
@@ -53,16 +53,15 @@ struct LevelSixView: View {
                     Alert(title: Text("UAU, a vista daqui de cima é linda!"), message: Text("Txai chegou à copa da árvore, mas seu estômago parece não estar acostumado com altura. Dê uma mãozinha para ajudá-lo com esse mal estar…"), dismissButton: .default(Text("Vamos lá!")))
                 })
                 ZStack{
-                    Image(won ? "happy-mushroom" : "dizzy-mushroom")
                     Circle()
-                        .fill(Color.black)
+                        .fill(Color.clear)
                         .opacity(0.2)
                         .frame(width: radius * 2, height: radius * 2)
                     
                     Circle()
-                        .fill(Color.red)
+                        .fill(Color.green)
                         .frame(width: radius, height: radius)
-                        .opacity(0.5)
+                        .opacity(0.3)
                         .offset(y: -radius/2)
                         .rotationEffect(Angle.degrees(Double(angleValue)))
                         .gesture(
@@ -87,8 +86,9 @@ struct LevelSixView: View {
                                     }
                                 }
                         )
+                    Image(won ? "happy-mushroom" : "dizzy-mushroom")
                     
-                    Text(won ? "Ganhou" : "")
+//                    Text(won ? "Ganhou" : "")
                     
                 }
                 


### PR DESCRIPTION
## What I did
1. Fixed the text that was in the middle of the screen on level 4
2. Adjusted the winning condition on level 5
3. Fixed the looks of the level 6 circles

## How to test
1. Pull this branch
2. Run the game
3. Go to level 4 and check if the text that used to show up in the middle of the screen is now inside the pop up alert
4. Go to level 5 and check if when you put the volume on max you win
5. Go to level 6 and check if there's no longer a black circle and if the red circle now shows up as green behind Txai (it should kind of blend in with the green in txai's face)